### PR TITLE
Fix a build error

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,5 +7,6 @@
   :source-paths ["src" "src/clojure"]
   :java-source-paths ["src/java" "gen"]
 
+  :javac-options ["-target" "1.6" "-source" "1.6" "-Xlint:-options"]
   :android {:library true
-            :target-sdk :ics})
+            :target-version :ics})


### PR DESCRIPTION
The key should be :target-version instead of :target-sdk. For some
reason, :ics was not working. An explicit "17" does. Explicit JVM
options make sure the resulting JAR can be DEXed.
