### PR TITLE
Doc fix for ref-adapter

### DIFF
--- a/src/clojure/neko/ui/adapters.clj
+++ b/src/clojure/neko/ui/adapters.clj
@@ -14,7 +14,7 @@
   data. Returns an Adapter object that displays ref-type contents.
   When ref-type is updated, Adapter gets updated as well.
 
-  `create-view-fn` is a nullary function. `update-view-fn` is
+  `create-view-fn` is a function of context. `update-view-fn` is
   a function of four arguments: element position, view to update,
   parent view container and the respective data element from the
   ref-type. `access-fn` argument is optional, it is called on the


### PR DESCRIPTION
`create-fn-view` requires one argument - context. Currently the docstring `(doc neko.ui.adapters/ref-adapter)` suggests, that the function takes no arguments, which later causes 
`clojure.lang.ArityException: Wrong number of args (1) passed to ... ` in https://github.com/clojure-android/neko/blob/master/src/clojure/neko/ui/adapters.clj#L30