### PR TITLE
Defpreference

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,18 +1,17 @@
 * [[https://raw.githubusercontent.com/clojure-android/neko/master/doc/big_logo.png]]
 
-  Neko is a toolkit designed to make Android development using Clojure
-  easier and more fun. It accomplishes this by making adding Clojure
-  support to your Android project easy and providing functional
-  wrappers and alternatives to Android’s Java API.
+  Neko is a toolkit designed to make Android development using Clojure easier
+  and more fun. It provides different facilities that wrap Android's Java API
+  and are more idiomatic to use from Clojure. Neko does not try to wrap every
+  API class or method, as they are always accessible to a developer through
+  interop. Instead Neko only offers substitutes to Java API where it really
+  simplifies the development and gives better understanding of the code.
 
-  Neko was originally written by [[https://github.com/sattvik][Daniel Solano Gómez]]. This version is
-  a fork by Alexander Yakushev as part of Google Summer of Code
-  2012/2013 participation project.
+  Neko is developed under [[http://clojure-android.info/][Clojure-Android initiative]].
 
 ** Installation
 
-   Just add the following line to the dependencies of your
-   Clojure/Android project:
+   Add the following line to the dependencies of your Clojure/Android project:
 
    [[https://clojars.org/neko][https://clojars.org/neko/latest-version.svg]]
 
@@ -29,7 +28,7 @@
 
    Marginalia docs are available [[http://clojure-android.github.io/neko/][here]].
 
-** How to build Neko yourself
+** Building Neko
 
    If you want to modify/extend Neko source code and then use it in
    your applications, you can build it yourself. Use =lein droid jar=
@@ -45,19 +44,22 @@
 
 ** Acknowledgments
 
-   I thank Remco van 't Veer for his [[https://github.com/remvee/clj-android][clj-android]] library which was one
-   of the pioneer attempts to bring Clojure to Android development.
-   Some features in my Neko fork are inspired by ideas from his
+   Neko was originally written by [[https://github.com/sattvik][Daniel Solano Gómez]]. This version is a fork by
+   Alexander Yakushev as part of Google Summer of Code 2012/2013 participation
    project.
+
+   I thank Remco van 't Veer for his [[https://github.com/remvee/clj-android][clj-android]] library which was one of the
+   pioneer attempts to bring Clojure to Android development. Some features in my
+   Neko fork are inspired by ideas from his project.
 
    I also thank all the [[https://github.com/alexander-yakushev/neko/graphs/contributors][contributors]] to Neko.
 
-   Cat icon used in the logo is designed by [[http://www.freepik.com/][Freepik]]  from Flaticon.com.
+   Cat icon used in the logo is designed by [[http://www.freepik.com/][Freepik]] from Flaticon.com.
 
 ** Legal information
 
    Copyright © 2011-2013 Sattvik Software & Technology Resources, Ltd.
-   Co., Alexander Yakushev
+   Co., 2012-2015 Alexander Yakushev
 
    All rights reserved.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject neko "3.2.0"
+(defproject neko "4.0.0-SNAPSHOT"
   :description "Neko is a toolkit designed to make Android development using Clojure easier and more fun."
   :url "https://github.com/clojure-android/neko"
   :license {:name "Eclipse Public License"

--- a/src/clojure/neko/compilation.clj
+++ b/src/clojure/neko/compilation.clj
@@ -23,7 +23,6 @@
   Note that additional invocations to init within the same process will not have
   any effect."
   {:author "Daniel Solano Gómez"}
-  (:use [neko.resource :only [get-resource]])
   (:import android.content.Context
            [java.io File FileNotFoundException]))
 

--- a/src/clojure/neko/context.clj
+++ b/src/clojure/neko/context.clj
@@ -1,48 +1,19 @@
-; Copyright © 2011 Sattvik Software & Technology Resources, Ltd. Co.
-; All rights reserved.
-;
-; This program and the accompanying materials are made available under the
-; terms of the Eclipse Public License v1.0 which accompanies this distribution,
-; and is available at <http://www.eclipse.org/legal/epl-v10.html>.
-;
-; By using this software in any fashion, you are agreeing to be bound by the
-; terms of this license.  You must not remove this notice, or any other, from
-; this software.
-
 (ns neko.context
   "Utilities to aid in working with a context."
   {:author "Daniel Solano Gómez"}
   (:require [neko.-utils :as u])
-  (:use [clojure.string :only [upper-case]])
-  (:import android.content.Context))
-
-(def ^{:doc "Stores Application instance that acts as context."}
-  ^Context context)
+  (:import android.content.Context
+           neko.App))
 
 (defmacro get-service
-  "Gets a system service from the context.  The type argument is a keyword that
-  names the service type.  Examples include :alarm for the alarm service and
+  "Gets a system service for the given type. Type is a keyword that names the
+  service. Examples include :alarm for the alarm service and
   :layout-inflater for the layout inflater service."
-  {:pre [(keyword? type)]
-   :forms '([context type])}
+  {:pre [(keyword? type)]}
   ([type]
-     (println "One-argument version is deprecated. Please use (get-service context type)")
-     `(get-service ~context ~type))
+   `(get-service neko.App/instance ~type))
   ([context type]
-     `(.getSystemService
-       context
-       ~(symbol (str (.getName Context) "/"
-                     (u/keyword->static-field (name type)) "_SERVICE")))))
-
-(defn inflate-layout
-  "Inflates the layout with the given ID."
-  {:forms '([context id])}
-  ([id]
-     (println "One-argument version is deprecated. Please use (inflate-layout context id)")
-     (inflate-layout context id))
-  ([context id]
-     {:pre [(integer? id)]
-      :post [(instance? android.view.View %)]}
-     (.. android.view.LayoutInflater
-         (from context)
-         (inflate ^Integer id nil))))
+   `(.getSystemService
+     ^Context context
+     ~(symbol (str (.getName Context) "/"
+                   (u/keyword->static-field (name type)) "_SERVICE")))))

--- a/src/clojure/neko/data.clj
+++ b/src/clojure/neko/data.clj
@@ -2,11 +2,11 @@
   "Contains utilities to manipulate data that is passed between
   Android entities via Bundles and Intents."
   (:refer-clojure :exclude [assoc!])
-  (:use [neko.context :only [context]])
   (:import android.os.Bundle android.content.Intent
            android.content.SharedPreferences
            android.content.SharedPreferences$Editor
-           android.content.Context))
+           android.content.Context
+           neko.App))
 
 (defprotocol GenericExtrasKey
   "If given a string returns itself, otherwise transforms a argument
@@ -93,14 +93,13 @@
 (defn get-shared-preferences
   "Returns the SharedPreferences object for the given name. Possible modes:
   `:private`, `:world-readable`, `:world-writeable`."
-  {:forms '([context name mode])}
   ([name mode]
-     (println "Two-argument version is deprecated. Please use (get-shared-preferences context name mode)"))
-  ([^Context context name mode]
-     {:pre [(or (number? mode) (contains? sp-access-modes mode))]}
-     (let [mode (if (number? mode)
-                  mode (sp-access-modes mode))]
-       (.getSharedPreferences context name mode))))
+   (get-shared-preferences App/instance name mode))
+  ([^Context context, name mode]
+   {:pre [(or (number? mode) (contains? sp-access-modes mode))]}
+   (let [mode (if (number? mode)
+                mode (sp-access-modes mode))]
+     (.getSharedPreferences context name mode))))
 
 (defn ^SharedPreferences$Editor assoc!
   "Puts the value into the SharedPreferences editor instance. Accepts

--- a/src/clojure/neko/data.clj
+++ b/src/clojure/neko/data.clj
@@ -132,3 +132,92 @@
   [sp-map key]
   (when-let [val (get sp-map key)]
    (read-string val)))
+
+(def sp "SharedPreferences manager for the application." (atom nil))
+(def ^:private preferences "Set of atoms to keep track of." (atom #{}))
+
+(defn- watch
+  "Watch function for saving preferences whenever they are edited."
+  [^SharedPreferences sp _key ref old new]
+  (when-not (= old new)
+    (when-not sp
+      (throw (java.lang.Exception
+              (str "shared-preferences not initialized: " sp))))
+    (locking sp
+      (-> (.edit sp)
+          (neko.data/assoc-arbitrary! (:sp-key (meta ref)) new)
+          .commit))))
+
+(defn track-and-set!
+  "Set the value of atom `a` according to the value stored in
+  `shared-prefs` (if any), then add a watch to it so any changes in
+  its value are updated in `shared-prefs`.
+  shared-prefs defaults to `sp`.
+  The atom must have an `:sp-key` meta property holding a string or a
+  keyword."
+  ([a]
+   (if @sp
+     (track-and-set! a @sp)
+     (throw (java.lang.Exception "shared-preferences not initialized"))))
+  ([a ^SharedPreferences sp]
+   {:pre [(instance? clojure.lang.Atom a)
+          (:sp-key (meta a))]}
+   (let [key (:sp-key (meta a))]
+     (locking sp
+       (try (let [msp (neko.data/like-map sp)]
+              (when (contains? msp key)
+                (reset! a (neko.data/get-arbitrary msp key))))
+            (catch java.lang.Exception e
+              (neko.log/e "Preference" key "couldn't be read, disregarding"))))
+     (add-watch a :shared-preferences-save-tracker
+                (partial watch sp)))))
+
+(defn initialize-preferences
+  "Restore the recorded value of all preferences, and configure them
+  to be saved when changed. Call this only once per application
+  lifetime.
+
+  This function can be invoked with either a SharedPreferences object,
+  or a name and a Context (as per `get-shared-preferences`). In the
+  latter case, this function will have no effect if preferences have
+  already been initialized in this session, unless a third truthy
+  argument is provided."
+  ([^Context context name]
+   (initialize-preferences context name false))
+  ([^Context context name force]
+   (when (or force (not @sp))
+     (initialize-preferences (neko.data/get-shared-preferences context name :private))))
+  ([^SharedPreferences shared-prefs]
+   (reset! sp shared-prefs)
+   (doseq [p @preferences]
+     (track-and-set! p shared-prefs))))
+
+(defmacro defpreference
+  "Define a shared preference, i.e., an atom whose value is saved
+  between sessions. Defines a var with `name`, whose value is an atom
+  containing `value`, optionally including a docstring. The actual
+  saving and restoring only takes place once the function
+  initialize-preferences is called, which should happen only once per
+  application lifetime, so call it in the onCreate of your main activity.
+
+  Once the function is called, any previously saved value will
+  override `value`, and a watcher will be used to always save the
+  value again when the atom is changed.
+
+  Additional keyword arguments accepted are:
+  :version -- Change this number to ignore previously saved values.
+  :key -- The key to use in `sp`, defaults to \"sp/namespace/name/version\".
+          Setting this invalidates the version argument.
+  :meta and :validator -- Passed to the atom."
+  ([name value]
+   `(defpreference ~name nil ~value))
+  ([name doc value & rest]
+   (if (odd? (count rest))
+     `(defpreference ~name nil ~doc ~value ~@rest)
+     (let [[& {:keys [key version meta validator]}] rest
+           sp-key (or key (str "sp/" *ns* "/" name "/" version))]
+       `(do (def ~name ~@(if doc [doc])
+              (atom ~value
+                    :meta ~(into {:sp-key sp-key} meta)
+                    :validator ~validator))
+            (swap! preferences conj ~name))))))

--- a/src/clojure/neko/debug.clj
+++ b/src/clojure/neko/debug.clj
@@ -33,8 +33,7 @@
   [e]
   (reset! ui-exception e)
   (neko.log/e "Exception raised on UI thread." :exception e)
-  (when-let [ctx (:neko.context/context all-activities)]
-    (neko.notify/toast ctx (str e) :long)))
+  (neko.notify/toast (str e) :long))
 
 (defn ui-e
   "Returns an uncaught exception happened on UI thread."

--- a/src/clojure/neko/dialog/alert.clj
+++ b/src/clojure/neko/dialog/alert.clj
@@ -19,9 +19,8 @@
   it is immutable.  Using the protocol with an AlertDialog.Builder object works
   by mutating the object."
   {:author "Daniel Solano Gómez"}
-  (:import android.app.AlertDialog$Builder)
-  (:use neko.context)
-  )
+  (:import android.app.AlertDialog$Builder
+           neko.App))
 
 (defprotocol AlertDialogBuilder
   "Defines the functionality needed to build new alert dialogues."
@@ -82,4 +81,4 @@
   "Creates a new functional alert dialog builder."
   []
   {:post [(instance? FunctionalAlertDialogBuilder %)]}
-  (FunctionalAlertDialogBuilder. context true))
+  (FunctionalAlertDialogBuilder. App/instance true))

--- a/src/clojure/neko/init.clj
+++ b/src/clojure/neko/init.clj
@@ -33,11 +33,6 @@
   (when-not @initialized?
     (alter-var-root #'neko.context/context (constantly context))
     (.put neko.debug/all-activities :neko.context/context context)
-    (alter-var-root #'neko.resource/package-name
-                    (constantly
-                     (let [^String pkg (.getPackageName ^Context context)]
-                       (if (.endsWith pkg ".debug")
-                         (subs pkg 0 (- (.length pkg) 6)) pkg))))
     (enable-dynamic-compilation context)
     ;; Ensure that `:port` is provided, pass all other arguments as-is.
     (start-nrepl-server port (mapcat identity (dissoc args :port)))

--- a/src/clojure/neko/listeners/adapter_view.clj
+++ b/src/clojure/neko/listeners/adapter_view.clj
@@ -24,6 +24,7 @@
   view      the view within the AdapterView that was clicked
   position  the position of the view in the adapter
   id        the row id of the item that was clicked"
+  ^android.widget.AdapterView$OnItemClickListener
   [handler-fn]
   {:pre  [(fn? handler-fn)]
    :post [(instance? android.widget.AdapterView$OnItemClickListener %)]}
@@ -55,6 +56,7 @@
 
   The function should evaluate to a logical true value if it has consumed the
   long click; otherwise logical false."
+  ^android.widget.AdapterView$OnItemLongClickListener
   [handler-fn]
   {:pre  [(fn? handler-fn)]
    :post [(instance? android.widget.AdapterView$OnItemLongClickListener %)]}
@@ -94,7 +96,8 @@
    {:pre  [(fn? item-fn)]
     :post [(instance? android.widget.AdapterView$OnItemSelectedListener %)]}
    (on-item-selected-call item-fn nil))
-  ([item-fn nothing-fn]
+  (^android.widget.AdapterView$OnItemSelectedListener
+   [item-fn nothing-fn]
    {:pre  [(fn? item-fn)
            (or (nil? nothing-fn)
                (fn? nothing-fn))]

--- a/src/clojure/neko/listeners/dialog.clj
+++ b/src/clojure/neko/listeners/dialog.clj
@@ -19,6 +19,7 @@
   "Takes a function and yields a DialogInterface.OnCancelListener object that
   will invoke the function.  This function must take one argument, the dialog
   that was canceled."
+  ^android.content.DialogInterface$OnCancelListener
   [handler-fn]
   (reify android.content.DialogInterface$OnCancelListener
     (onCancel [this dialog]
@@ -38,6 +39,7 @@
   dialog: the dialog that received the click
   which:  the button that was clicked (one of :negative, :neutral, or
           :positive) or the position of the item that was clicked"
+  ^android.content.DialogInterface$OnClickListener
   [handler-fn]
   (reify android.content.DialogInterface$OnClickListener
     (onClick [this dialog which]
@@ -63,6 +65,7 @@
   "Takes a function and yields a DialogInterface.OnDismissListener object that
   will invoke the function.  This function must take one argument, the dialog
   that was dismissed."
+  ^android.content.DialogInterface$OnDismissListener
   [handler-fn]
   (reify android.content.DialogInterface$OnDismissListener
     (onDismiss [this dialog]
@@ -85,6 +88,7 @@
 
   The function should evaluate to a logical true value if it has consumed the
   event, otherwise logical false."
+  ^android.content.DialogInterface$OnKeyListener
   [handler-fn]
   (reify android.content.DialogInterface$OnKeyListener
     (onKey [this dialog key-code event]
@@ -112,6 +116,7 @@
   dialog:   the dialog where the selection was made
   which:    the position of the item in the list that was clicked
   checked?: true if the click checked the item, else false"
+  ^android.content.DialogInterface$OnMultiChoiceClickListener
   [handler-fn]
   (reify android.content.DialogInterface$OnMultiChoiceClickListener
     (onClick [this dialog which checked?]

--- a/src/clojure/neko/listeners/search_view.clj
+++ b/src/clojure/neko/listeners/search_view.clj
@@ -8,6 +8,7 @@
   a SearchView.OnQueryTextListener object that will invoke the
   functions. Both functions take string argument, a query that was
   entered."
+  ^android.widget.SearchView$OnQueryTextListener
   [change-fn submit-fn]
   (reify android.widget.SearchView$OnQueryTextListener
     (onQueryTextChange [this query]

--- a/src/clojure/neko/listeners/text_view.clj
+++ b/src/clojure/neko/listeners/text_view.clj
@@ -30,6 +30,7 @@
   The function should evaluate to a logical true value if it has consumed the
   action, otherwise logical false."
   [handler-fn]
+  ^android.widget.TextView$OnEditorActionListener
   {:pre  [(fn? handler-fn)]
    :post [(instance? android.widget.TextView$OnEditorActionListener %)]}
   (reify android.widget.TextView$OnEditorActionListener

--- a/src/clojure/neko/listeners/view.clj
+++ b/src/clojure/neko/listeners/view.clj
@@ -19,6 +19,7 @@
   "Takes a function and yields a View.OnClickListener object that will invoke
   the function.  This function must take one argument, the view that was
   clicked."
+  ^android.view.View$OnClickListener
   [handler-fn]
   (reify android.view.View$OnClickListener
     (onClick [this view]
@@ -40,6 +41,7 @@
   view: the view for which the context menu is being built
   info: extra information about the item for which the context menu should be
         shown.  This information will vary depending on the class of view."
+  ^android.view.View$OnCreateContextMenuListener
   [handler-fn]
   (reify android.view.View$OnCreateContextMenuListener
     (onCreateContextMenu [this menu view info]
@@ -62,6 +64,7 @@
   "Takes a function and yields a View.OnDragListener object that will invoke
   the function.  This function must take the two arguments described in
   on-drag and should return a boolean."
+  ^android.view.View$OnDragListener
   [handler-fn]
   (reify android.view.View$OnDragListener
     (onDrag [this view event]
@@ -82,6 +85,7 @@
 
   view:     the view whose state has changed
   focused?: the new focused state for view"
+  ^android.view.View$OnFocusChangeListener
   [handler-fn]
   (reify android.view.View$OnFocusChangeListener
     (onFocusChange [this view focused?]
@@ -107,6 +111,7 @@
 
   The function should evaluate to a logical true value if it has consumed the
   event, otherwise logical false."
+  ^android.view.View$OnKeyListener
   [handler-fn]
   (reify android.view.View$OnKeyListener
     (onKey [this view key-code event]
@@ -130,6 +135,7 @@
   "Takes a function and yields a View.OnLayoutChangeListener object that
   will invoke the function.  This function must take the arguments  described
   in on-layout-change."
+  ^android.view.View$OnLayoutChangeListener
   [handler-fn]
   (reify android.view.View$OnLayoutChangeListener
     (onLayoutChange [this view left top right bottom
@@ -160,6 +166,7 @@
   invoke the function.  This function must take one argument, the view that was
   clicked, and must evaluate to a logical true value if it has consumed the
   long click, otherwise logical false."
+  ^android.view.View$OnLongClickListener
   [handler-fn]
   (reify android.view.View$OnLongClickListener
     (onLongClick [this view]
@@ -179,6 +186,7 @@
   that will invoke the function.  This function must take one argument, the
   view that was clicked, and must evaluate to true if it has consumed the long
   click, false otherwise."
+  ^android.view.View$OnSystemUiVisibilityChangeListener
   [handler-fn]
   (reify android.view.View$OnSystemUiVisibilityChangeListener
     (onLongClick [this view]
@@ -201,6 +209,7 @@
 
   The function should evaluate to a logical true value if it consumes the
   event, otherwise logical false."
+  ^android.view.View$OnTouchListener
   [handler-fn]
   (reify android.view.View$OnTouchListener
     (onTouch [this view event]

--- a/src/clojure/neko/resource.clj
+++ b/src/clojure/neko/resource.clj
@@ -2,7 +2,7 @@
   "Provides utilities to resolve application resources."
   (:import android.content.Context
            android.graphics.drawable.Drawable
-           neko.Application))
+           neko.App))
 
 (defmacro import-all
   "Imports all existing application's R subclasses (R$drawable, R$string etc.)
@@ -26,7 +26,7 @@
   [& args]
   (let [[^Context context args] (if (instance? Context (first args))
                                   [(first args) (rest args)]
-                                  [Application/instance args])
+                                  [App/instance args])
         [res-id & format-args] args]
     (cond (string? res-id) res-id
           format-args      (.getString context res-id (to-array format-args))
@@ -36,7 +36,7 @@
   "Gets a Drawable object associated with the given resource ID. If res-id is a
   Drawable, returns it unchanged."
   ([res-id]
-   (get-drawable Application/instance res-id))
+   (get-drawable App/instance res-id))
 
   ([^Context context, res-id]
    (if (instance? Drawable res-id)

--- a/src/clojure/neko/resource.clj
+++ b/src/clojure/neko/resource.clj
@@ -1,177 +1,44 @@
 (ns neko.resource
   "Provides utilities to resolve application resources."
-  (:require [clojure.string :as string]
-            [neko.context :as context])
-  (:import android.content.Context android.graphics.drawable.Drawable))
-
-(def package-name (:neko.init/package-name *compiler-options*))
+  (:import android.content.Context
+           android.graphics.drawable.Drawable
+           neko.Application))
 
 (defmacro import-all
   "Imports all existing application's R subclasses (R$drawable, R$string etc.)
   into the current namespace."
   []
-  `(do ~@(for [res-type '[anim drawable color layout menu
-                          string array plurals style id dimen]]
-           `(try (import '~(symbol (str package-name ".R$" res-type)))
-                 (catch ClassNotFoundException _# nil)))))
+  `(do ~@(map (fn [res-type]
+                `(try (import '~(-> (:neko.init/package-name *compiler-options*)
+                                    (str ".R$" res-type)
+                                    symbol))
+                      (catch ClassNotFoundException _# nil)))
+              '[anim drawable color layout menu string array plurals style id
+                dimen])))
 
 ;; ## Runtime resource resolution
 
-(defn- kw-to-res-name
-  "Takes the name of the keyword and turns all hyphens and periods to
-  underscores."
-  [kw]
-  (-> (name kw)
-      (string/replace \- \_)
-      (string/replace \. \_)))
-
-(defn get-resource
-  "Resolves the resource ID of a given type with the given name.  For example,
-  to refer to what in Java would be R.string.my_string, you can use:
-
-    `(get-resource :string :my-string)`
-
-  The type should be a keyword corresponding to a resource type such as
-  :layout, :attr, or :id.
-
-  The name should be a keyword.  If the keyword has a namespace, it will be
-  used as the package from which to retrieve the resources.  Generally, this is
-  not required as the default will be the application package.  However, this
-  can be used to access the resources from the platform.  For example, the
-  equivalent to android.R.layout.simple_list_item_1 is:
-
-    `(get-resource :layout :android/simple-list-item-1)`
-
-  The name portion of the name argument will be converted to a string and any
-  hyphens or periods will be transformed to underscores.  Note that hyphens are
-  not valid in Android names, but are allowed here to be Clojure friendly.
-
-  If the name argument is an integer, it is assumed to be a valid resource ID
-  and will be returned as is without any processing."
-  ([res-type res-name]
-     (println "Two-argument version is deprecated. Please use (get-resource context res-type res-name)")
-     (get-resource context/context res-type res-name))
-  ([^Context context, res-type res-name]
-     (let [resid (if (keyword? res-name)
-                      (.getIdentifier (.getResources context)
-                                      (kw-to-res-name res-name)
-                                      (name res-type)
-                                      (or (namespace res-name)
-                                          (.getPackageName context)))
-                      res-name)]
-       (if (= resid 0) nil resid))))
-
-(defn get-id
-  "Finds the ID for the XML item with the given name. This is simply a
-  convenient way of calling `(get-resource context :id name)`."
-  ([res-name]
-     (println "One-argument version is deprecated. Please use (get-id context res-name)")
-     (get-resource context/context :id res-name))
-  ([^Context context, res-name]
-     (get-resource context :id res-name)))
-
-(defn get-layout
-  "Finds the resource ID for the layout with the given name. This is simply a
-  convenient way of calling `(get-resource context :layout name)`."
-  ([res-name]
-     (println "One-argument version is deprecated. Please use (get-layout context res-name)")
-     (get-resource context/context :layout res-name))
-  ([^Context context, res-name]
-     (get-resource context :layout res-name)))
-
 (defn get-string
-  "Gets the localized string with the given ID or name from the context.
-  The name will be resolved using get-resource. If res-name is a
-  string, returns it unchanged.
-
-  If additional arguments are supplied, the string will be interpreted as a
-  format and the arguments will be applied to the format."
-  {:forms '([context res-name & format-args?]) }
+  "Gets the localized string for the given resource ID. If res-name is a string,
+  returns it unchanged. If additional arguments are supplied, the string will be
+  interpreted as a format and the arguments will be applied to the format."
+  {:forms '([res-id & format-args?] [context res-id & format-args?])}
   [& args]
   (let [[^Context context args] (if (instance? Context (first args))
                                   [(first args) (rest args)]
-                                  [context/context args])
-        [res-name & format-args] args]
-    (if-not (or (keyword? res-name) (number? res-name))
-      res-name
-      (when-let [id (get-resource context :string res-name)]
-        (if format-args
-          (.getString context id (to-array format-args))
-          (.getString context id))))))
+                                  [Application/instance args])
+        [res-id & format-args] args]
+    (cond (string? res-id) res-id
+          format-args      (.getString context res-id (to-array format-args))
+          :else            (.getString context res-id))))
 
 (defn get-drawable
-  "Gets a Drawable object associated with the given ID or name from
-  the context. The name will be resolved using get-resource. If
-  res-name is a Drawable, returns it unchanged."
-  ([res-name]
-     (println "One-argument version is deprecated. Please use (get-drawable context res-name)")
-     (get-drawable context/context res-name))
-  ([^Context context, res-name]
-     (if (instance? Drawable res-name)
-       res-name
-       (when-let [id (get-resource context :drawable res-name)]
-         (.getDrawable (.getResources context) id)))))
+  "Gets a Drawable object associated with the given resource ID. If res-id is a
+  Drawable, returns it unchanged."
+  ([res-id]
+   (get-drawable Application/instance res-id))
 
-;; Compile time resource resolution
-
-(defn- resource-symbol
-  "Returns a symbol that represents a resource field specified by type
-  and name keywords. If `name` is not a keyword, just returns it back."
-  [res-type res-name]
-  (if (not (keyword? res-name))
-    name
-    (let [package (or (namespace res-name) package-name)
-          res-type (name res-type)
-          res-name (kw-to-res-name res-name)]
-      (symbol (str package ".R$" res-type "/" res-name)))))
-
-(defmacro resolve-resource
-  "Resolves a resource identifier by its type and name. This is the
-  same as `get-resource`, but executes in compile-time."
-  [type name]
-  {:pre  [(keyword? type)]}
-  (resource-symbol type name))
-
-(defmacro resolve-id
-  "Finds the resource ID for the XML item with the given name in
-  compile time. This is simply a convenient way of calling
-  `(resolve-resource :id name)`."
-  [name]
-  (resource-symbol :id name))
-
-(defn resolve-id-reader
-  [name]
-  (resource-symbol :id name))
-
-(defmacro resolve-string
-  "Finds the resource ID for the string with the given name in compile
-  time. This is simply a convenient way of calling `(resolve-resource
-  :string name)`."
-  [name]
-  (resource-symbol :string name))
-
-(defn resolve-string-reader
-  [name]
-  (resource-symbol :string name))
-
-(defmacro resolve-layout
-  "Finds the resource ID for the layout with the given name in compile
-  time. This is simply a convenient way of calling `(resolve-resource
-  :layout name)`."
-  [name]
-  (resource-symbol :layout name))
-
-(defn resolve-layout-reader
-  [name]
-  (resource-symbol :layout name))
-
-(defmacro resolve-drawable
-  "Finds the resource ID for the Drawable with the given name in compile
-  time. This is simply a convenient way of calling `(resolve-resource
-  :drawable name)`."
-  [name]
-  (resource-symbol :drawable name))
-
-(defn resolve-drawable-reader
-  [name]
-  (resource-symbol :drawable name))
+  ([^Context context, res-id]
+   (if (instance? Drawable res-id)
+     res-id
+     (.getDrawable (.getResources context) res-id))))

--- a/src/clojure/neko/ui.clj
+++ b/src/clojure/neko/ui.clj
@@ -1,10 +1,9 @@
 (ns neko.ui
   "Tools for defining and manipulating Android UI elements."
-  (:use [neko.-utils :only [keyword->setter reflect-setter reflect-constructor]]
-        [neko.listeners.view :only [on-click-call]]
-        [neko.ui.traits :only [apply-trait]])
   (:require [neko.ui.mapping :as kw]
-            [neko.context :as context]))
+            [neko.ui.traits :refer [apply-trait]]
+            [neko.-utils :refer [keyword->setter reflect-setter
+                                 reflect-constructor]]))
 
 ;; ## Attributes
 
@@ -87,12 +86,8 @@
   following:
 
   `[element-name map-of-attributes & subelements]`."
-  {:forms '([activity tree])}
-  ([tree]
-     (println "One-argument version is deprecated. Please use (make-ui activity tree)")
-     (make-ui-element context/context tree {}))
-  ([activity tree]
-     (make-ui-element activity tree {})))
+  [activity tree]
+  (make-ui-element activity tree {}))
 
 (defn config
   "Takes a widget and key-value pairs of attributes, and applies these
@@ -100,3 +95,15 @@
   [widget & {:as attributes}]
   (apply-attributes (kw/keyword-by-classname (type widget))
                     widget attributes {}))
+
+;; ## Compatibility with Android XML UI facilities.
+
+(defn inflate-layout
+  "Renders a View object for the given XML layout ID."
+  [activity id]
+  {:pre [(integer? id)]
+   :post [(instance? android.view.View %)]}
+  (.. android.view.LayoutInflater
+      (from activity)
+      (inflate ^Integer id nil)))
+

--- a/src/clojure/neko/ui/mapping.clj
+++ b/src/clojure/neko/ui/mapping.clj
@@ -8,6 +8,7 @@
             ImageView ImageView$ScaleType RelativeLayout ScrollView FrameLayout
             Gallery]
            android.app.ProgressDialog
+           android.view.inputmethod.EditorInfo
            [android.view View ViewGroup$LayoutParams Gravity]))
 
 ;; This atom keeps all the relations inside the map.
@@ -34,7 +35,23 @@
     :frame-layout {:classname android.widget.FrameLayout
                    :inherits :view-group}
     :edit-text {:classname android.widget.EditText
-                :inherits :view}
+                :inherits :view
+                :values {:number      EditorInfo/TYPE_CLASS_NUMBER
+                         :datetime    EditorInfo/TYPE_CLASS_DATETIME
+                         :text        EditorInfo/TYPE_CLASS_TEXT
+                         :phone       EditorInfo/TYPE_CLASS_PHONE
+                         :go          EditorInfo/IME_ACTION_GO
+                         :done        EditorInfo/IME_ACTION_DONE
+                         :unspecified EditorInfo/IME_ACTION_UNSPECIFIED
+                         :send        EditorInfo/IME_ACTION_SEND
+                         :search      EditorInfo/IME_ACTION_SEARCH
+                         :previous    EditorInfo/IME_ACTION_PREVIOUS
+                         :next        EditorInfo/IME_ACTION_NEXT}}
+    :progress-bar {:classname android.widget.ProgressBar
+                   :inherits  :view
+                   :value-namespaces {:visibility android.view.View}}
+    :progress-bar-large {:inherits  :progress-bar
+                         :constructor-args [nil android.R$attr/progressBarStyleLarge]}
     :text-view {:classname android.widget.TextView
                 :inherits :view
                 :value-namespaces

--- a/src/clojure/neko/ui/mapping.clj
+++ b/src/clojure/neko/ui/mapping.clj
@@ -5,7 +5,8 @@
   (:require [clojure.string :as string])
   (:use [neko.-utils :only [keyword->static-field reflect-field]])
   (:import [android.widget LinearLayout Button EditText ListView SearchView
-            ImageView ImageView$ScaleType RelativeLayout ScrollView]
+            ImageView ImageView$ScaleType RelativeLayout ScrollView FrameLayout
+            Gallery]
            android.app.ProgressDialog
            [android.view View ViewGroup$LayoutParams Gravity]))
 
@@ -17,7 +18,8 @@
            :traits [:def :id :padding :on-click :on-long-click :on-touch
                     :on-create-context-menu :on-key
                     :default-layout-params :linear-layout-params
-                    :relative-layout-params :listview-layout-params]
+                    :relative-layout-params :listview-layout-params
+                    :frame-layout-params :gallery-layout-params]
            :value-namespaces
            {:gravity android.view.Gravity}}
     :view-group {:inherits :view
@@ -29,6 +31,8 @@
                     :inherits :view-group}
     :relative-layout {:classname android.widget.RelativeLayout
                       :inherits :view-group}
+    :frame-layout {:classname android.widget.FrameLayout
+                   :inherits :view-group}
     :edit-text {:classname android.widget.EditText
                 :inherits :view}
     :text-view {:classname android.widget.TextView
@@ -51,7 +55,10 @@
                :inherits :view}
     :scroll-view {:classname android.widget.ScrollView
                   :inherits :view}
-
+    :gallery {:classname android.widget.Gallery
+              :inherits :view-group
+              :traits [:on-item-click]}
+    
     ;; Other
     :layout-params {:classname ViewGroup$LayoutParams
                     :values {:fill ViewGroup$LayoutParams/FILL_PARENT
@@ -73,12 +80,14 @@
    {android.widget.Button :button
     android.widget.LinearLayout :linear-layout
     android.widget.RelativeLayout :relative-layout
+    android.widget.FrameLayout :frame-layout
     android.widget.EditText :edit-text
     android.widget.TextView :text-view
     android.widget.ListView :list-view
     android.widget.ImageView :image-view
     android.webkit.WebView :web-view
     android.widget.ScrollView :scroll-view
+    android.widget.Gallery :gallery
     android.app.ProgressDialog :progress-dialog}))
 
 (defn set-classname!

--- a/src/clojure/neko/ui/menu.clj
+++ b/src/clojure/neko/ui/menu.clj
@@ -1,11 +1,10 @@
 (ns neko.ui.menu
   "Provides utilities for declarative options menu generation.
   Intended to replace XML-based menu layouts."
-  (:require [neko.context :as ctx]
-            [neko.ui :as ui])
-  (:use [neko.ui.mapping :only [defelement]]
-        [neko.ui.traits :only [deftrait to-id]]
-        [neko.-utils :only [call-if-nnil]])
+  (:require [neko.ui :as ui]
+            [neko.ui.mapping :refer [defelement]]
+            [neko.ui.traits :refer [deftrait to-id]]
+            [neko.-utils :refer [call-if-nnil]])
   (:import [android.view Menu MenuItem]
            [android.view View ActionMode$Callback]
            android.app.Activity))
@@ -151,15 +150,14 @@
 ;; ### ActionView attribute
 
 (deftrait :action-view
-  "Takes `:action-view` attribute which should either be a View
-  instance or a UI definition tree, and sets it as an action view for
-  the menu item. For UI tree syntax see docs for `neko.ui/make-ui`.
-  Activity instance should be provided via `:context` attribute."
+  "Takes `:action-view` attribute which should either be a View instance or a UI
+  definition tree, and sets it as an action view for the menu item. For UI tree
+  syntax see docs for `neko.ui/make-ui`. Activity instance must be provided via
+  `:context` attribute."
   {:attributes [:action-view :context]
    :applies? (:action-view attrs)}
   [^MenuItem wdg, {:keys [action-view context] :as attrs} _]
   (let [view (if (instance? View action-view)
                action-view
-               (ui/make-ui-element (or context ctx/context)
-                                   action-view {:menu-item wdg}))]
+               (ui/make-ui-element context action-view {:menu-item wdg}))]
     (.setActionView wdg ^View view)))

--- a/src/clojure/neko/ui/traits.clj
+++ b/src/clojure/neko/ui/traits.clj
@@ -138,8 +138,8 @@ next-level elements."
 ;; ### Basic traits
 
 (deftrait :text
-  "Sets widget's text to a string, integer ID or a keyword
-  representing the string resource provided to `:text` attribute."
+  "Sets widget's text to a string or a resource ID representing a string
+  resource provided to `:text` attribute."
   [^TextView wdg, {:keys [text] :or {text ""}} _]
   (.setText wdg ^CharSequence (res/get-string text)))
 
@@ -183,7 +183,6 @@ next-level elements."
   (condp instance? image
     Bitmap (.setImageBitmap wdg image)
     Drawable (.setImageDrawable wdg image)
-    Keyword (.setImageDrawable wdg (neko.resource/get-drawable image))
     Uri (.setImageURI wdg image)
     ;; Otherwise assume `image` to be resource ID.
     (.setImageResource wdg image)))

--- a/src/clojure/neko/ui/traits.clj
+++ b/src/clojure/neko/ui/traits.clj
@@ -447,7 +447,7 @@ next-level elements."
   "Takes :on-editor-action attribute, which should be function
   of three arguments, and sets it as OnEditorAction for the
   TexView widget"
-  [^TextView wdg, {:keys [on-editor-action]}]
+  [^TextView wdg, {:keys [on-editor-action]} _]
   (.setOnEditorActionListener wdg (text-view-listeners/on-editor-action-call on-editor-action)))
 
 ;; ### ID storing traits

--- a/src/data_readers.clj
+++ b/src/data_readers.clj
@@ -1,5 +1,0 @@
-{res/id neko.resource/resolve-id-reader
- res/layout neko.resource/resolve-layout-reader
- res/string neko.resource/resolve-string-reader
- res/drawable neko.resource/resolve-drawable-reader}
-

--- a/src/java/neko/ActivityWithState.java
+++ b/src/java/neko/ActivityWithState.java
@@ -1,0 +1,7 @@
+package neko;
+
+public interface ActivityWithState {
+
+    public Object getState();
+
+}

--- a/src/java/neko/App.java
+++ b/src/java/neko/App.java
@@ -2,17 +2,25 @@ package neko;
 
 import android.util.Log;
 import clojure.java.api.Clojure;
+import clojure.lang.DalvikDynamicClassLoader;
 import clojure.lang.Var;
 import clojure.lang.IFn;
 
-public class Application extends android.app.Application {
+public class App extends android.app.Application {
 
-    private static String TAG = "neko.Application";
-    public static Application instance;
+    private static String TAG = "neko.App";
+    public static App instance;
 
     @Override
     public void onCreate() {
         instance = this;
+        DalvikDynamicClassLoader.setContext(this);
+        // ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        // Log.d(TAG, "What's the loader! " + loader);
+        // if (loader instanceof DalvikDynamicClassLoader) {
+        //     Log.d(TAG, "INSIDE!");
+        //     ((DalvikDynamicClassLoader)loader).initializeDynamicCompilation(this);
+        // }
     }
 
     // This method is only necessary for asynchronous loading. Clojure is

--- a/src/java/neko/Application.java
+++ b/src/java/neko/Application.java
@@ -1,0 +1,50 @@
+package neko;
+
+import android.util.Log;
+import clojure.java.api.Clojure;
+import clojure.lang.Var;
+import clojure.lang.IFn;
+
+public class Application extends android.app.Application {
+
+    private static String TAG = "neko.Application";
+    public static Application instance;
+
+    @Override
+    public void onCreate() {
+        instance = this;
+    }
+
+    // This method is only necessary for asynchronous loading. Clojure is
+    // perfectly capable of loading itself the first time anything from it is
+    // called.
+    public static void loadClojure() {
+        IFn load = Clojure.var("clojure.core", "load");
+        load.invoke("/neko/init");
+
+        IFn init = Clojure.var("neko.init", "init");
+        init.invoke(instance);
+    }
+
+    public static void loadAsynchronously(final String activityClass, final Runnable callback) {
+        new Thread(Thread.currentThread().getThreadGroup(),
+                   new Runnable(){
+                       @Override
+                       public void run() {
+                           loadClojure();
+
+                           try {
+                               Class.forName(activityClass);
+                           } catch (ClassNotFoundException e) {
+                               Log.e(TAG, "Failed loading activity " + activityClass, e);
+                           }
+
+                           callback.run();
+                       }
+                   },
+                   "ClojureLoadingThread",
+                   1048576 // = 1MB, thread stack size in bytes
+                   ).start();
+    }
+
+}


### PR DESCRIPTION
This PR defines a `defpreference` macro. Using this macro to define a variable will define an atom instead, and its value will be recorded throughout sessions, assuming `initialize-preferences` is called at some point.

This is an initial proposal, let me know what you think of the implementation.
In particular, there's no real need for the `sp` variable. I just included it in case the user wants to edit some values manually, but it could be removed.