### PR TITLE
Enable :on-drag trait and tweak project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,10 +6,11 @@
 
   :dependencies [[org.clojure-android/clojure "1.7.0-r2"]
                  [com.android.support/multidex "1.0.0" :extension "aar"]]
-  :plugins [[lein-droid "0.4.1-SNAPSHOT"]]
+  :plugins [[lein-droid "0.4.6"]]
 
   :source-paths ["src/clojure"]
   :java-source-paths ["src/java"]
+  :javac-options ["-target" "1.6" "-source" "1.6" "-Xlint:-options"]
 
   :profiles {:default [:android-common]
 

--- a/src/clojure/neko/listeners/view.clj
+++ b/src/clojure/neko/listeners/view.clj
@@ -59,7 +59,6 @@
   [& body]
   `(on-create-context-menu-call (fn [~'menu ~'view ~'info] ~@body)))
 
-(comment -- Introduced in SDK version 11 (Honeycomb)
 (defn on-drag-call
   "Takes a function and yields a View.OnDragListener object that will invoke
   the function.  This function must take the two arguments described in
@@ -77,7 +76,7 @@
   view:  the view that received the drag event
   event: the DragEvent object for the drag event"
   [& body]
-  `(on-drag-call (fn [~'view ~'event] ~@body))))
+  `(on-drag-call (fn [~'view ~'event] ~@body)))
 
 (defn on-focus-change-call
   "Takes a function and yields a View.OnFocusChangeListener object that will

--- a/src/clojure/neko/ui/mapping.clj
+++ b/src/clojure/neko/ui/mapping.clj
@@ -16,8 +16,8 @@
   (atom
    ;; UI widgets
    {:view {:classname android.view.View
-           :traits [:def :id :padding :on-click :on-long-click :on-touch
-                    :on-create-context-menu :on-key :on-focus-change
+           :traits [:def :id :padding :on-click :on-drag :on-long-click
+                    :on-touch :on-create-context-menu :on-key :on-focus-change
                     :default-layout-params :linear-layout-params
                     :relative-layout-params :listview-layout-params
                     :frame-layout-params :gallery-layout-params]

--- a/src/clojure/neko/ui/traits.clj
+++ b/src/clojure/neko/ui/traits.clj
@@ -413,6 +413,12 @@ next-level elements."
   [^View wdg, {:keys [on-touch]} _]
   (.setOnTouchListener wdg (view-listeners/on-touch-call on-touch)))
 
+(deftrait :on-drag
+  "Takes :on-drag attribute, which should be function of two
+  arguments, and sets it as an OnDragListener for the widget."
+  [^View wdg, {:keys [on-drag]} _]
+  (.setOnDragListener wdg (view-listeners/on-drag-call on-drag)))
+
 (deftrait :on-query-text
   "Takes `:on-query-text-change` and `:on-query-text-submit`
   attributes, which should be functions of one or two arguments,


### PR DESCRIPTION
The functionality for the :on-drag trait seems to have existed since the initial commit, but for whatever reason wasn't enabled.  This was an attempt at enabling it.

Along the way a couple of additional bits turned up:

1) With build-tools >= 24 + leiningen 2.7.x (and possibly other bits), something didn't work right for neko (may be it was the local tests that didn't run and possibly other things).  Changing the lein-droid version in project.clj to 0.4.6 seems to cope with the issue.

2) When building a coa project with an updated local neko jar, got a "Unsupported Class file version 52.0" error [1] during dex creation.  Tweaking neko's project.clj by adding the following seems to help:

```clojure
  :javac-options ["-target" "1.6" "-source" "1.6" "-Xlint:-options"]
```

Note the line is just cribbed from what typically appears in a fresh coa project's project.cljl

Sorry about the vagueness.  If it's desirable, I can try to track down the specifics.

At any rate, with the included changes, I was able to use the :on-drag trait successfully.

[1] https://stackoverflow.com/questions/37902840/got-unsupported-class-file-version-52-0-after-including-a-module-to-a-project
https://github.com/phax/ph-css/issues/28