### PR TITLE
Make :container trait handle proxies of android.* classses

### DIFF
--- a/src/clojure/neko/_utils.clj
+++ b/src/clojure/neko/_utils.clj
@@ -128,3 +128,12 @@
                                (.getName m)))
                            (.getDeclaredMethods c))))
       methods)))
+
+(defn closest-android-ancestor
+  [^Class c]
+  (loop [c c]
+    (when c
+      (if-let [cand-name
+               (re-find #"^class (android\..*)" (str c))]
+        (Class/forName (second cand-name))
+        (recur (.getSuperclass c))))))

--- a/src/clojure/neko/ui/traits.clj
+++ b/src/clojure/neko/ui/traits.clj
@@ -6,7 +6,7 @@
             [neko.listeners.text-view :as text-view-listeners]
             [neko.listeners.adapter-view :as adapter-view]
             neko.listeners.search-view
-            [neko.-utils :refer [memoized int-id]])
+            [neko.-utils :refer [memoized int-id closest-android-ancestor]])
   (:import [android.widget LinearLayout$LayoutParams ListView TextView SearchView
             ImageView RelativeLayout RelativeLayout$LayoutParams AdapterView
             AbsListView$LayoutParams FrameLayout$LayoutParams Gallery$LayoutParams]
@@ -367,7 +367,7 @@ next-level elements."
   use the container type to choose the correct LayoutParams instance."
   {:applies? (constantly true)}
   [wdg _ __]
-  (let [kw (kw/keyword-by-classname (type wdg))
+  (let [kw (kw/keyword-by-classname (closest-android-ancestor (class wdg)))
         container-type (-> (kw/get-keyword-mapping) kw :container-type)]
     {:options-fn #(assoc % :container-type (or container-type kw))}))
 


### PR DESCRIPTION
Currently, :custom-constructor doesn't appear to work for proxied container widgets:

```clojure
{:custom-constructor
 (fn [ctxt]
   (proxy [LinearLayout] [ctxt]))
```

leads to an error at runtime.

The deftrait for :container has:

```clojure
(let [kw (kw/keyword-by-classname (type wdg))
```

So IIUC, if wdg is a proxy, kw becomes nil.

As a work-around, I added a function 'closest-android-ancestor' which tries to determine the 'closest' android.* ancestor (actually, the starting class is also considered).  Replacing the aforementioned line with:

```clojure
(let [kw (kw/keyword-by-classname (closest-android-ancestor (class wdg)))
```

yields better results here.

Likely there's a better way :)
